### PR TITLE
Handle prefix dirs in S3 folder structure

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -170,6 +170,8 @@ def add_partition(session, database, table_name, partition, bucket):
     sql = 'ALTER TABLE ' + table_name + ' ADD PARTITION ('
 
     partition_key_vals = partition.split('/')
+    # Filter out any prefix dirs from the key
+    partition_key_vals = [p for p in partition_key_vals if "=" in p]
     partiton_key_count = len(partition_key_vals)
 
     for part in partition_key_vals:


### PR DESCRIPTION
If the partitions exist under a prefix this fix will ignore the prefix and work on the partitions only
e.g. S3 path with a prefix before partitions:
events/year=2020/month=03/day=25/hour=22/

The code was breaking on my setup until I made this change.